### PR TITLE
feat(DEVEX-202): add jira parameters to check PR title action

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -19,3 +19,7 @@ jobs:
 
       - name: Check PR Title
         uses: CloudTalk-io/action-check-pr-title@main
+        with:
+          jiraUrl: ${{ vars.JIRA_URL }}
+          jiraUsername: ${{ secrets.JIRA_USERNAME }}
+          jiraToken: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
## Jira Task link

[DEVEX-202](https://cloudtalk.atlassian.net/browse/DEVEX-202)

## Why is this change required

We want to ensure that all PRs contain parent task JIRA ID. If you also want to link subtasks, PR should contain multiple IDs (check Jira Task link).

## What changed

Adding parameters needed for check-pr-title action to connect to JIRA and check whether the task in PR title is parent task. Regex used to detect JIRA task ID was also changed [here](https://github.com/CloudTalk-io/action-check-pr-title/pull/1).

[DEVEX-202]: https://cloudtalk.atlassian.net/browse/DEVEX-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ